### PR TITLE
fix(migration-helpers): plugin migration can't find utils files

### DIFF
--- a/migration-helpers/update-plugin-folder-structure.js
+++ b/migration-helpers/update-plugin-folder-structure.js
@@ -30,12 +30,18 @@ async function migratePlugin(v3PluginPath, v4DestinationPath) {
 
     // Create root strapi-admin
     const strapiAdmin = join(v4Plugin, `strapi-admin.js`);
-    await fs.copy("./utils/strapi-admin.js", strapiAdmin);
+    await fs.copy(
+      join(__dirname, "..", "utils", "strapi-admin.js"),
+      strapiAdmin
+    );
     console.log(`created ${strapiAdmin}`);
 
     // Create root strapi-server
     const strapiServer = join(v4Plugin, `strapi-server.js`);
-    await fs.copy("./utils/strapi-server.js", strapiServer);
+    await fs.copy(
+      join(__dirname, "..", "utils", "strapi-server.js"),
+      strapiServer
+    );
     console.log(`created ${strapiServer}`);
 
     // Move all server files to /server


### PR DESCRIPTION
Hi @markkaylor 👋🏻

I just tried the plugin migration feature, it appears that he can't find the `utils/strapi-admin.js` & `utils/strapi-server.js` files.
It throws the following error: `ENOENT: no such file or directory, lstat './utils/strapi-admin.js'`

So I made a fix about it in order to create a path based on `__dirname` & join `utils` path as you made in other part of the code

PS: I'm working on a CLI prompt based of this repo in order to add some UX to this tools and be easier to use in lot of project. (I'll do a PR tomorrow about it ☺️) If you want more informations about it, feel free to contact me on discord 🙌🏻