### PR TITLE
add lifecycles to content-types

### DIFF
--- a/migration-helpers/update-plugin-folder-structure.js
+++ b/migration-helpers/update-plugin-folder-structure.js
@@ -34,6 +34,7 @@ async function migratePlugin(v3PluginPath, v4DestinationPath) {
       join(__dirname, "..", "utils", "strapi-admin.js"),
       strapiAdmin
     );
+    
     console.log(`created ${strapiAdmin}`);
 
     // Create root strapi-server
@@ -42,6 +43,7 @@ async function migratePlugin(v3PluginPath, v4DestinationPath) {
       join(__dirname, "..", "utils", "strapi-server.js"),
       strapiServer
     );
+
     console.log(`created ${strapiServer}`);
 
     // Move all server files to /server
@@ -54,10 +56,14 @@ async function migratePlugin(v3PluginPath, v4DestinationPath) {
           "use-arrow-function-for-service-export"
         );
       }
+
       // Create index file for directory
       if (directory === "models") {
         await convertModelToContentType(join(v4Plugin, "server"));
-        await createContentTypeIndex(join(v4Plugin, "server", "content-types"));
+        await createContentTypeIndex(
+          v4Plugin,
+          join(v4Plugin, "server", "content-types")
+        );
       } else {
         await createDirectoryIndex(join(v4Plugin, "server", directory));
       }
@@ -97,9 +103,9 @@ async function moveBootstrapFunction(pluginPath) {
 }
 
 async function moveToServer(v4Plugin, originDir, serverDir) {
-  const exists = await fs.pathExists(join(v4Plugin, originDir, serverDir));
-  if (!exists) return;
-
+  const exists = await fs.exists(join(v4Plugin, originDir, serverDir));
+  if (!exists) return
+  
   const origin = join(v4Plugin, originDir, serverDir);
   const destination = join(v4Plugin, "server", serverDir);
   await fs.move(origin, destination);
@@ -118,20 +124,24 @@ async function createServerIndex(serverDir) {
   await addModulesToExport(indexPath, filesToImport);
 }
 
-async function createContentTypeIndex(dir) {
+async function createContentTypeIndex(v4PluginPath, dir) {
   const hasDir = await fs.pathExists(dir);
   if (!hasDir) return;
 
   const indexPath = join(dir, "index.js");
 
   await fs.copy(join(__dirname, "..", "utils", "module-exports.js"), indexPath);
-  const dirContent = await fs.readdir(dir);
-  const filesToImport = dirContent
-    .filter((file) => file !== "index.js")
-    .map((file) => `${file}/schema`);
+  const dirContent = await fs.readdir(dir, { withFileTypes: true });
+  const directoriesToImport = dirContent
+    .filter((fd) => fd.isDirectory())
+    .map((fd) => fd.name);
 
-  await importFilesToIndex(indexPath, filesToImport);
-  await addModulesToExport(indexPath, filesToImport);
+  for (dir of directoriesToImport) {
+    createDirectoryIndex(join(v4PluginPath, "server", "content-types", dir));
+  }
+
+  await importFilesToIndex(indexPath, directoriesToImport);
+  await addModulesToExport(indexPath, directoriesToImport);
 }
 
 async function createDirectoryIndex(dir) {


### PR DESCRIPTION
- Adapts the convert-models-to-content-types so that lifecycle hooks are taken into account
- fixes an error when no model directory is found