### PR TITLE
Use of NPM Registry over api.npms.io

### DIFF
--- a/migration-helpers/update-package-dependencies.js
+++ b/migration-helpers/update-package-dependencies.js
@@ -7,8 +7,8 @@ const axios = require("axios");
 const { strapiPackages, toBeDeleted } = require("../utils/strapi-packages");
 
 async function getLatestStrapiVersion() {
-  const response = await axios.get(`https://api.npms.io/v2/package/${encodeURIComponent('@strapi/strapi')}`);
-  return response.data.collected.metadata.version;
+  const response = await axios.get(`https://registry.npmjs.org/${encodeURIComponent("@strapi/strapi")}`);
+  return response.data["dist-tags"].latest;
 }
 
 async function updatePackageDependencies(appPath) {


### PR DESCRIPTION
## Description
It seems that the `api.npms.io` is often down (I keep getting 500 error tonight).
That's why we should go over **NPM Registry** thanks `registry.npmjs.com` which allow us to get informations about published package. (The informations are the exact copy of what you can find inside `package.json`)