### PR TITLE
add --git-dir and --work-tree to isCleanGitRepo check

### DIFF
--- a/lib/global/utils/is-clean-git-repo.js
+++ b/lib/global/utils/is-clean-git-repo.js
@@ -15,7 +15,7 @@ const isCleanGitRepo = async (path) => {
   }
 
   try {
-    const { stdout } = await execa('git', ['status', '--porcelain']);
+    const { stdout } = await execa('git', [`--git-dir=${path}/.git`, `--work-tree=${path}`, 'status', '--porcelain']);
     if (stdout.length)
       throw Error(
         `The ${chalk.yellow('git')} directory at ${chalk.yellow(resolve(path))} is not clean`


### PR DESCRIPTION
allows script to be run against a remote directory