### PR TITLE
add rename logic and helper file

### DIFF
--- a/lib/v4/migration-helpers/rename-collection-types.js
+++ b/lib/v4/migration-helpers/rename-collection-types.js
@@ -1,0 +1,16 @@
+const fs = require('fs-extra')
+const { join } = require('path');
+
+module.exports = async (path, oldName, newName) => {
+	const oldPath = join(path, oldName)
+	const newPath = join(path, newName)
+	await fs.rename(oldPath, newPath)
+	await fs.rename(join(newPath, 'controllers', `${oldName}.js`), join(newPath, 'controllers', `${newName}.js`))
+	const documentationDirs = await fs.readdir(join(newPath, 'documentation')) 
+	for (dir of documentationDirs) {
+		await fs.rename(join(newPath, 'documentation', '1.0.0', `${oldName}.json`), join(newPath, 'documentation', dir, `${newName}.json`))
+	}
+	await fs.rename(join(newPath, 'services', `${oldName}.js`), join(newPath, 'services', `${newName}.js`))
+	await fs.rename(join(newPath, 'models', `${oldName}.js`), join(newPath, 'models', `${newName}.js`))
+	await fs.rename(join(newPath, 'models', `${oldName}.settings.json`), join(newPath, 'models', `${newName}.settings.json`))
+}

--- a/lib/v4/migration-helpers/update-api-folder-structure.js
+++ b/lib/v4/migration-helpers/update-api-folder-structure.js
@@ -12,6 +12,8 @@ const { logger } = require('../../global/utils');
 const updateContentTypes = require('./convert-models-to-content-types');
 const updateRoutes = require('./update-routes');
 const updatePolicies = require('./update-api-policies');
+const renameCollectionTypes = require('./rename-collection-types')
+const pluralize = require('pluralize');
 
 const normalizeName = _.kebabCase;
 
@@ -78,7 +80,11 @@ const updateApiFolderStructure = async (appPath) => {
   const apiDirs = await getDirsAtPath(apiDirCopyPath);
 
   for (const api of apiDirs) {
-    const apiName = normalizeName(api.name);
+    let apiName = pluralize.singular(normalizeName(api.name));
+    if(apiName !== api.name) {
+      await renameCollectionTypes(apiDirCopyPath, api.name, apiName)
+      api.name = apiName
+    }   
     const apiPath = join(apiDirCopyPath, apiName);
     await updateContentTypes(apiPath);
     await updateRoutes(apiPath, apiName);


### PR DESCRIPTION
First pass at auto renaming files and directories in the api folder during a migrate. Resolves issues with v3 configured with plural or non kebab-case collection-type names. 