### PR TITLE
fixes route migration

### DIFF
--- a/lib/v4/migration-helpers/__mocks__/mock-routes-v4.js
+++ b/lib/v4/migration-helpers/__mocks__/mock-routes-v4.js
@@ -1,26 +1,28 @@
-module.exports = [
-  {
-    method: 'GET',
-    path: '/test',
-    handler: 'test.index',
-    config: {
-      policies: [],
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/test',
+      handler: 'test.index',
+      config: {
+        policies: [],
+      },
     },
-  },
-  {
-    method: 'POST',
-    path: '/test/create',
-    handler: 'test.create',
-    config: {
-      policies: [],
+    {
+      method: 'POST',
+      path: '/test/create',
+      handler: 'test.create',
+      config: {
+        policies: [],
+      },
     },
-  },
-  {
-    method: 'PUT',
-    path: '/test/:id',
-    handler: 'test.update',
-    config: {
-      policies: [],
+    {
+      method: 'PUT',
+      path: '/test/:id',
+      handler: 'test.update',
+      config: {
+        policies: [],
+      },
     },
-  },
-];
+  ],
+};

--- a/lib/v4/migration-helpers/update-routes.js
+++ b/lib/v4/migration-helpers/update-routes.js
@@ -30,8 +30,11 @@ module.exports = async (apiPath, apiName) => {
       (route) => !route.handler.includes('count') || !route.path.includes('count')
     );
 
+    // Changes routes back into an object with the routes property
+    const updatedRoutesObject = {routes: updatedRoutes};
+
     // Transform objects to strings
-    const routesToString = inspect(updatedRoutes, { depth: Infinity });
+    const routesToString = inspect(updatedRoutesObject, { depth: Infinity });
 
     // Export routes from create js file
     file.write(`module.exports = ${routesToString}`);

--- a/lib/v4/migration-helpers/update-routes.js
+++ b/lib/v4/migration-helpers/update-routes.js
@@ -31,7 +31,7 @@ module.exports = async (apiPath, apiName) => {
     );
 
     // Changes routes back into an object with the routes property
-    const updatedRoutesObject = {routes: updatedRoutes};
+    const updatedRoutesObject = { routes: updatedRoutes };
 
     // Transform objects to strings
     const routesToString = inspect(updatedRoutesObject, { depth: Infinity });


### PR DESCRIPTION
[According to this](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/routes.html#migrating-custom-routers) the custom routes for v4 are formatted like: 
```
module.exports = {
  routes: [
    { // Path defined with a URL parameter
      method: 'GET',
      path: '/restaurants/:category/:id',
      handler: 'Restaurant.findOneByCategory',
    },
    { // Path defined with a regular expression
      method: 'GET',
      path: '/restaurants/:region(\\d{2}|\\d{3})/:id', // Only match when the first parameter contains 2 or 3 digits.
      handler: 'Restaurant.findOneByRegion',
    },
    { // Route with custom policies
      method: 'POST',
      path: "/restaurants/:id/reservation",
      handler: 'Restaurant.reservation',
      config: {
        policies: ["is-authenticated", "has-credit-card"]
      }
    }
  ]
}
```

so I changed it to that from:

```
module.exports =  [
    { // Path defined with a URL parameter
      method: 'GET',
      path: '/restaurants/:category/:id',
      handler: 'Restaurant.findOneByCategory',
    },
    { // Path defined with a regular expression
      method: 'GET',
      path: '/restaurants/:region(\\d{2}|\\d{3})/:id', // Only match when the first parameter contains 2 or 3 digits.
      handler: 'Restaurant.findOneByRegion',
    },
    { // Route with custom policies
      method: 'POST',
      path: "/restaurants/:id/reservation",
      handler: 'Restaurant.reservation',
      config: {
        policies: ["is-authenticated", "has-credit-card"]
      }
    }
  ];

```
including the test