### PR TITLE
Remove yarn commands, only use npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,6 @@
 
 ## Getting started
 
-### ⏳ Installation
-
-```bash
-yarn add @strapi/codemods
-```
-
-**or**
-
-```bash
-npm install --save @strapi/codemods
-```
-
 ### 🖐 Requirements
 
 Before running any commands, be sure you have initialized a git repository, the working tree is clean, you've pushed your code to GitHub, and you are on a new branch.
@@ -33,12 +21,6 @@ Before running any commands, be sure you have initialized a git repository, the 
 #### Migrate
 
 _Usage with prompt_
-
-```bash
-yarn @strapi/codemods migrate
-```
-
-or
 
 ```bash
 npx @strapi/codemods migrate
@@ -60,13 +42,13 @@ To bypass the prompts use one of the following commands:
 - `Application` migration
 
 ```bash
-yarn @strapi/codemods migrate:application <path>
+npx @strapi/codemods migrate:application <path>
 ```
 
 - `Plugin` migration
 
 ```bash
-yarn @strapi/codemods migrate:plugin <path> [pathForV4Plugin]
+npx @strapi/codemods migrate:plugin <path> [pathForV4Plugin]
 ```
 
 > Note: if no `pathForV4Plugin` is provided it will be created at `<path>-v4`
@@ -74,18 +56,12 @@ yarn @strapi/codemods migrate:plugin <path> [pathForV4Plugin]
 - `Dependencies` migration
 
 ```bash
-yarn @strapi/codemods migrate:dependencies <path>
+npx @strapi/codemods migrate:dependencies <path>
 ```
 
 #### Transform
 
 :warning: _This command will modify your source code. Be sure you have initialized a git repository, the working tree is clean, you've pushed your code to GitHub, and you are on a new branch._
-
-```bash
-yarn @strapi/codemods transform
-```
-
-or
 
 ```bash
 npx @strapi/codemods transform


### PR DESCRIPTION
### What does it do

Removes yarn commands from the README and only suggests using npx.

### Why is it needed?

Npx allows users to run the command without the package in the their project's dependencies and ensures they are using the latest version

### Related issues/PRs
closes [#27](https://github.com/strapi/codemods/issues/27)
closes https://github.com/strapi/codemods/pull/35