### PR TITLE
use name lifecycles.js for file containing a content-type's lifecycles

### DIFF
--- a/lib/v4/migration-helpers/__tests__/convert-models-to-content-types.test.js
+++ b/lib/v4/migration-helpers/__tests__/convert-models-to-content-types.test.js
@@ -59,7 +59,7 @@ describe('convert models to content types', () => {
     expect(fs.readJSON).toHaveBeenCalledWith(expectedPath);
   });
 
-  it('creates the v4 shcema.json', async () => {
+  it('creates the v4 schema.json', async () => {
     fs.exists.mockReturnValueOnce(true).mockReturnValueOnce(true);
 
     const dirPath = './test-dir';
@@ -91,5 +91,20 @@ describe('convert models to content types', () => {
         spaces: 2,
       }
     );
+  });
+
+  it('creates the v4 lifecycles.js', async () => {
+    const dirPath = './test-dir';
+    const v3LifecyclesPath = join(dirPath, 'models', 'test.js');
+
+    fs.exists
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(true)
+      .mockImplementationOnce((path) => path === v3LifecyclesPath);
+
+    await convertModelsToContentTypes(dirPath);
+
+    const expectedV4LifecyclesPath = join(dirPath, 'content-types', 'test', 'lifecycles.js');
+    expect(fs.move).toHaveBeenCalledWith(v3LifecyclesPath, expectedV4LifecyclesPath);
   });
 });

--- a/lib/v4/migration-helpers/convert-models-to-content-types.js
+++ b/lib/v4/migration-helpers/convert-models-to-content-types.js
@@ -103,7 +103,7 @@ const convertModelToContentType = async (apiPath, contentTypeName) => {
   const lifecyclePath = join(apiPath, 'models', `${contentTypeName}.js`);
   const lifecyclesExist = await fs.exists(lifecyclePath);
 
-  const v4LifecyclesPath = join(apiPath, 'content-types', contentTypeName, 'lifecycle.js');
+  const v4LifecyclesPath = join(apiPath, 'content-types', contentTypeName, 'lifecycles.js');
 
   if (lifecyclesExist) {
     try {


### PR DESCRIPTION
The [docs](https://docs.strapi.io/developer-docs/latest/development/backend-customization/models.html#lifecycle-hooks) mention that lifecycle hooks belong in a file called _lifecycles.js_, but the v3 -> v4 codemods previously moved them to _lifecycle.js_.

I got no feedback to my discord message so I here is a PR that changes that and also adds a unit test for it.

![image](https://user-images.githubusercontent.com/11959747/193214010-5ec3d8d8-f721-4f9b-9372-79ae3c9465df.png)