### PR TITLE
Adds component migration and fixes sqlite3 depends

### DIFF
--- a/lib/v4/migration-helpers/convert-components.js
+++ b/lib/v4/migration-helpers/convert-components.js
@@ -13,6 +13,7 @@ const getRelationObject = require('./get-relation-object');
  * @description Migrates component json to v4 structure with nested relations
  *
  * @param {string} componentsPath Path to the components folder
+ * @param {string} componentCategory Name of the current component's category
  * @param {string} componentName Name of the current component
  */
 const convertComponent = async (componentsPath, componentCategory, componentName) => {

--- a/lib/v4/migration-helpers/convert-components.js
+++ b/lib/v4/migration-helpers/convert-components.js
@@ -1,0 +1,109 @@
+/**
+ * Migrate components to v4 structure
+ */
+const fs = require('fs-extra');
+const _ = require('lodash');
+const pluralize = require('pluralize');
+
+const { isPlural, isSingular } = pluralize;
+const logger = require('../../global/utils/logger');
+const getRelationObject = require('./get-relation-object');
+
+/**
+ * @description Migrates component json to v4 structure with nested relations
+ *
+ * @param {string} componentsPath Path to the components folder
+ * @param {string} componentName Name of the current component
+ */
+const convertComponent = async (componentsPath, componentCategory, componentName) => {
+  console.log(componentsPath)
+  const componentExists = await fs.exists(componentsPath);
+  if (!componentExists) {
+    logger.error(`${componentCategory}/${componentName}.json does not exist`);
+    return;
+  }
+
+  try {
+    // Read the component.json file
+    const componentJson = await fs.readJSON(componentsPath);
+    // Create a copy
+    const v4ComponentJson = { ...componentJson };
+    if (v4ComponentJson.info.name) {
+      v4ComponentJson.info.displayName = v4ComponentJson.info.name;
+      delete v4ComponentJson.info.name;
+    }
+
+    if (componentJson.attributes) {
+      Object.entries(componentJson.attributes).forEach(([key, attribute]) => {
+        // Not a relation, return early
+        if (!attribute.via && !attribute.collection && !attribute.model) return;
+
+        if (
+          attribute.plugin === 'upload' &&
+          (attribute.model === 'file' || attribute.collection === 'file')
+        ) {
+          // Handle the Media Plugin
+          attribute = {
+            type: 'media',
+            allowedTypes: attribute.allowedTypes,
+            multiple: _.has(attribute, 'collection'),
+            required: attribute.required,
+            private: attribute.private,
+          };
+        } else if (
+          attribute.plugin === 'admin' &&
+          (attribute.model === 'user' || attribute.collection === 'user')
+        ) {
+          // Handle admin user relation
+          attribute = {
+            type: 'relation',
+            target: 'admin::user',
+            relation: _.has(attribute, 'collection') ? 'oneToMany' : 'oneToOne',
+          };
+
+          if (attribute.private) {
+            attribute.private = true;
+          }
+        } else if (attribute.via && attribute.model && isSingular(attribute.via)) {
+          // One-To-One
+          attribute = getRelationObject('oneToOne', { ...attribute, inversed: true });
+        } else if (attribute.model && !attribute.via && !attribute.collection) {
+          // One-To-One (One-Way)
+          attribute = getRelationObject('oneToOne', { ...attribute, inversed: false });
+        } else if (attribute.via && attribute.model && isPlural(attribute.via)) {
+          // Many-To-One
+          attribute = getRelationObject('manyToOne', { ...attribute, inversed: true });
+        } else if (attribute.via && attribute.collection && isPlural(attribute.via)) {
+          // Many-To-Many
+          attribute = getRelationObject('manyToMany', {
+            ...attribute,
+            inversed: attribute.dominant,
+          });
+        } else if (attribute.collection && !attribute.via && !attribute.model) {
+          // Many-Way
+          attribute = getRelationObject('oneToMany', attribute);
+        } else if (attribute.via && attribute.collection) {
+          // One-To-Many
+          attribute = getRelationObject('oneToMany', { ...attribute, inversed: false });
+        } else {
+          logger.warn(`unknown relation type, please fix manually: ${key}`);
+        }
+
+        _.set(componentJson, `attributes.${key}`, attribute);
+      });
+    }
+
+    // Create the new content-types/api/schema.json file
+    await fs.ensureFile(componentsPath);
+    // Write modified JSON to schema.json
+    await fs.writeJSON(componentsPath, componentJson, {
+      spaces: 2,
+    });
+  } catch (error) {
+    logger.error(
+      `an error occurred when trying to migrate ${componentCategory}/${componentName}.json`
+    );
+  }
+};
+
+module.exports = convertComponent;

--- a/lib/v4/migration-helpers/convert-components.js
+++ b/lib/v4/migration-helpers/convert-components.js
@@ -16,7 +16,6 @@ const getRelationObject = require('./get-relation-object');
  * @param {string} componentName Name of the current component
  */
 const convertComponent = async (componentsPath, componentCategory, componentName) => {
-  console.log(componentsPath)
   const componentExists = await fs.exists(componentsPath);
   if (!componentExists) {
     logger.error(`${componentCategory}/${componentName}.json does not exist`);
@@ -26,11 +25,9 @@ const convertComponent = async (componentsPath, componentCategory, componentName
   try {
     // Read the component.json file
     const componentJson = await fs.readJSON(componentsPath);
-    // Create a copy
-    const v4ComponentJson = { ...componentJson };
-    if (v4ComponentJson.info.name) {
-      v4ComponentJson.info.displayName = v4ComponentJson.info.name;
-      delete v4ComponentJson.info.name;
+    if (componentJson.info.name) {
+      componentJson.info.displayName = componentJson.info.name;
+      delete componentJson.info.name;
     }
 
     if (componentJson.attributes) {
@@ -93,9 +90,9 @@ const convertComponent = async (componentsPath, componentCategory, componentName
       });
     }
 
-    // Create the new content-types/api/schema.json file
+    // Ensure the component.json file exists
     await fs.ensureFile(componentsPath);
-    // Write modified JSON to schema.json
+    // Write modified JSON to component.sjon
     await fs.writeJSON(componentsPath, componentJson, {
       spaces: 2,
     });

--- a/lib/v4/migration-helpers/update-api-folder-structure/index.js
+++ b/lib/v4/migration-helpers/update-api-folder-structure/index.js
@@ -11,13 +11,14 @@ const { Liquid } = require('liquidjs');
 const pluralize = require('pluralize');
 const runJscodeshift = require('../../utils/run-jscodeshift');
 const { logger } = require('../../../global/utils');
+const updateComponents = require('../convert-components')
 const updateContentTypes = require('../convert-models-to-content-types');
 const updateRoutes = require('../update-application-routes');
 const updateControllers = require('../update-application-controllers');
 const updateServices = require('../update-application-services');
 const updatePolicies = require('../update-api-policies');
 const renameApiFilesToSingular = require('../rename-api-files-to-singular');
-const { getDirsAtPath, cleanEmptyDirectories } = require('./utils');
+const { getDirsAtPath, getFilesAtPath, cleanEmptyDirectories } = require('./utils');
 
 const liquidEngine = new Liquid({
   root: resolve(__dirname, 'templates'),
@@ -27,6 +28,7 @@ const liquidEngine = new Liquid({
 const updateApiFolderStructure = async (appPath) => {
   const strapiAppPath = resolve(appPath);
   const apiDirCopyPath = join(strapiAppPath, 'src', 'api');
+  const componentDirCopyPath = join(strapiAppPath, 'src', 'components');
 
   try {
     // Copy the api folder to the v3 folder for safe keeping
@@ -38,12 +40,35 @@ const updateApiFolderStructure = async (appPath) => {
     process.exit(1);
   }
 
+  try {
+    // Copy the components folder to the v3 folder for safe keeping
+    await fs.copy(join(strapiAppPath, 'components'), join(strapiAppPath, 'v3', 'components'));
+    // Move the original components folder to src/components
+    await fs.move(join(strapiAppPath, 'components'), componentDirCopyPath);
+  } catch (error) {
+    logger.warn(`${basename(strapiAppPath)}/components not found, skipping`);
+  }
+
+  // Migrate extensions
   const extensionPath = join(strapiAppPath, 'src', 'extensions');
   const extensionDirs = await getDirsAtPath(extensionPath);
   for (const extension of extensionDirs) {
     await updateContentTypes(join(extensionPath, extension.name));
   }
 
+  // Migrate Components
+  const componentCategoryDirs = await getDirsAtPath(componentDirCopyPath);
+  for (const category of componentCategoryDirs) {
+    const componentFiles = await getFilesAtPath(join(componentDirCopyPath, category.name));
+    for (const component of componentFiles) {
+      let componentName = component.name.replace('.json', '');
+      let componentPath = join(componentDirCopyPath, category.name, component.name);
+
+      await updateComponents(componentPath, category.name, componentName);
+    }
+  }
+
+  // Migrate Content Types
   const apiDirs = await getDirsAtPath(apiDirCopyPath);
   for (const api of apiDirs) {
     let apiSingularName = pluralize.singular(_.kebabCase(api.name));

--- a/lib/v4/migration-helpers/update-api-folder-structure/index.js
+++ b/lib/v4/migration-helpers/update-api-folder-structure/index.js
@@ -11,7 +11,7 @@ const { Liquid } = require('liquidjs');
 const pluralize = require('pluralize');
 const runJscodeshift = require('../../utils/run-jscodeshift');
 const { logger } = require('../../../global/utils');
-const updateComponents = require('../convert-components')
+const updateComponents = require('../convert-components');
 const updateContentTypes = require('../convert-models-to-content-types');
 const updateRoutes = require('../update-application-routes');
 const updateControllers = require('../update-application-controllers');
@@ -22,8 +22,8 @@ const { getDirsAtPath, getFilesAtPath, cleanEmptyDirectories } = require('./util
 
 const liquidEngine = new Liquid({
   root: resolve(__dirname, 'templates'),
-  extname: '.liquid'
-})
+  extname: '.liquid',
+});
 
 const updateApiFolderStructure = async (appPath) => {
   const strapiAppPath = resolve(appPath);
@@ -36,7 +36,11 @@ const updateApiFolderStructure = async (appPath) => {
     // Move the original api folder to src/api
     await fs.move(join(strapiAppPath, 'api'), apiDirCopyPath);
   } catch (error) {
-    logger.error(`${basename(strapiAppPath)}/api or ${basename(strapiAppPath)}/config not found, are you sure this is a Strapi app?`);
+    logger.error(
+      `${basename(strapiAppPath)}/api or ${basename(
+        strapiAppPath
+      )}/config not found, are you sure this is a Strapi app?`
+    );
     process.exit(1);
   }
 
@@ -57,15 +61,19 @@ const updateApiFolderStructure = async (appPath) => {
   }
 
   // Migrate Components
+  if (fs.existsSync(componentDirCopyPath)) {
   const componentCategoryDirs = await getDirsAtPath(componentDirCopyPath);
-  for (const category of componentCategoryDirs) {
-    const componentFiles = await getFilesAtPath(join(componentDirCopyPath, category.name));
-    for (const component of componentFiles) {
-      let componentName = component.name.replace('.json', '');
-      let componentPath = join(componentDirCopyPath, category.name, component.name);
+    for (const category of componentCategoryDirs) {
+      const componentFiles = await getFilesAtPath(join(componentDirCopyPath, category.name));
+      for (const component of componentFiles) {
+        let componentName = component.name.replace('.json', '');
+        let componentPath = join(componentDirCopyPath, category.name, component.name);
 
-      await updateComponents(componentPath, category.name, componentName);
+        await updateComponents(componentPath, category.name, componentName);
+      }
     }
+  } else {
+    logger.warn('No components found, skipping');
   }
 
   // Migrate Content Types
@@ -88,7 +96,7 @@ const updateApiFolderStructure = async (appPath) => {
     );
   }
   logger.info(`migrated ${chalk.yellow(basename(strapiAppPath))} to Strapi v4 🚀`);
-  logger.warn('Custom config, controllers, services, and routes were not migrated')
+  logger.warn('Custom config, controllers, services, and routes were not migrated');
   logger.warn('These will need to be updated manually');
   logger.info(`to see changes: Run ${chalk.yellow('git add . && git diff --cached')}`);
   logger.info(

--- a/lib/v4/migration-helpers/update-api-folder-structure/index.js
+++ b/lib/v4/migration-helpers/update-api-folder-structure/index.js
@@ -61,7 +61,7 @@ const updateApiFolderStructure = async (appPath) => {
   }
 
   // Migrate Components
-  if (fs.existsSync(componentDirCopyPath)) {
+  if (await fs.exists(componentDirCopyPath)) {
   const componentCategoryDirs = await getDirsAtPath(componentDirCopyPath);
     for (const category of componentCategoryDirs) {
       const componentFiles = await getFilesAtPath(join(componentDirCopyPath, category.name));

--- a/lib/v4/migration-helpers/update-api-folder-structure/utils/index.js
+++ b/lib/v4/migration-helpers/update-api-folder-structure/utils/index.js
@@ -13,6 +13,10 @@ const getDirsAtPath = async (path) => {
   return dir.filter((fd) => fd.isDirectory());
 };
 
+const getFilesAtPath = async (path) => {
+  return fs.readdir(path, { withFileTypes: true });
+};
+
 /**
  *
  * @description Recursively removes empty directories
@@ -40,4 +44,4 @@ const cleanEmptyDirectories = async (dirs, baseDir) => {
   }
 };
 
-module.exports = { cleanEmptyDirectories, getDirsAtPath };
+module.exports = { cleanEmptyDirectories, getDirsAtPath, getFilesAtPath };

--- a/lib/v4/migration-helpers/update-application-folder-structure.js
+++ b/lib/v4/migration-helpers/update-application-folder-structure.js
@@ -38,7 +38,7 @@ module.exports = async (appPath) => {
 
   // Do some cleanup on the application folder
   moveDir(strapiAppPath, 'admin', srcDir);
-  moveDir(strapiAppPath, 'components', srcDir);
+  // moveDir(strapiAppPath, 'components', srcDir);
   moveDir(strapiAppPath, 'extensions', srcDir);
   moveDir(strapiAppPath, 'middlewares', srcDir);
   moveDir(strapiAppPath, 'plugins', srcDir);

--- a/lib/v4/migration-helpers/update-application-folder-structure.js
+++ b/lib/v4/migration-helpers/update-application-folder-structure.js
@@ -38,7 +38,6 @@ module.exports = async (appPath) => {
 
   // Do some cleanup on the application folder
   moveDir(strapiAppPath, 'admin', srcDir);
-  // moveDir(strapiAppPath, 'components', srcDir);
   moveDir(strapiAppPath, 'extensions', srcDir);
   moveDir(strapiAppPath, 'middlewares', srcDir);
   moveDir(strapiAppPath, 'plugins', srcDir);

--- a/lib/v4/migration-helpers/update-package-dependencies.js
+++ b/lib/v4/migration-helpers/update-package-dependencies.js
@@ -56,6 +56,10 @@ const updatePackageDependencies = async (appPath) => {
         // Replace dependency if there's a matching v4 package
         v4PackageJSON.dependencies[newStrapiDependency] = latestStrapiVersion;
       }
+    } else if (depName === 'sqlite3') {
+      // The dependency is sqlite, switch to new package
+      delete v4PackageJSON.dependencies[depName];
+      v4PackageJSON.dependencies['better-sqlite3'] = '^7.6.2';
     }
   });
 


### PR DESCRIPTION
## What this PR does

- [x] Creates a new migration for components (yes it's in the api folder migration, I don't want to change it)
- [x] Handles component relations and migrates them to v4
- [x] Swaps out `sqlite3` depends for `better-sqlite3`

## How to test

- Create a content-type that contains a component
- Component should have a relation
- Run migration and validated the component's relation is properly migrated to v4 syntax

fixes #44