### PR TITLE
Fix UP extensions conversion

### DIFF
--- a/lib/v4/migration-helpers/convert-models-to-content-types.js
+++ b/lib/v4/migration-helpers/convert-models-to-content-types.js
@@ -39,6 +39,15 @@ const convertModelToContentType = async (apiPath, contentTypeName) => {
       name: contentTypeName,
     };
 
+    if (
+        schemaJson.collectionName === 'users-permissions_user' ||
+        schemaJson.collectionName === 'users-permissions_permission' ||
+        schemaJson.collectionName === 'users-permissions_role'
+    ) {
+      let newPrefix = schemaJson.collectionName.replace('users-permissions_', 'up_');
+      schemaJson.collectionName = pluralize(newPrefix);
+    }
+
     // Modify the JSON
     _.set(schemaJson, 'info', infoUpdate);
 


### PR DESCRIPTION
fixes #47

We have to handle users-permissions plugin extensions differently than normal since we renamed the models in v4. The collectionName wasn't being updated. This PR specifically checks for that and uses replace + pluralize to convert to the proper name.